### PR TITLE
Moved Window.__nidium__ object creation to a seperate method.

### DIFF
--- a/src/Binding/JSWindow.cpp
+++ b/src/Binding/JSWindow.cpp
@@ -1140,7 +1140,7 @@ JSWindow *JSWindow::GetObject(NidiumJS *njs)
 JSClass *JSWindow::GetJSClass()
 {
     static JSClass global_class = {
-        "Window",         
+        "Window",
         JSCLASS_GLOBAL_FLAGS_WITH_SLOTS(16) | JSCLASS_HAS_PRIVATE,
         nullptr,  nullptr,
         nullptr,  nullptr,
@@ -1149,7 +1149,7 @@ JSClass *JSWindow::GetJSClass()
         nullptr,  nullptr,
         nullptr,  JS_GlobalObjectTraceHook
     };
-    
+
     return &global_class;
 }
 
@@ -1196,6 +1196,27 @@ JSFunctionSpec *JSWindow::ListMethods()
     return funcs;
 }
 
+void JSWindow::RegisterNidiumObject(JSContext *cx)
+{
+    JS::RootedObject windowObj(cx, JS::CurrentGlobalOrNull(cx));
+    JS::RootedObject nidiumObj(cx, JS_NewPlainObject(cx));
+
+    JS::RootedString jVersion(cx, JS_NewStringCopyZ(cx, NIDIUM_VERSION_STR));
+    JS_DefineProperty(cx, nidiumObj, "version", jVersion,
+                      JSPROP_PERMANENT | JSPROP_ENUMERATE | JSPROP_READONLY);
+
+    JS::RootedString jBuild(cx, JS_NewStringCopyZ(cx, NIDIUM_BUILD));
+    JS_DefineProperty(cx, nidiumObj, "build", jBuild,
+                      JSPROP_PERMANENT | JSPROP_ENUMERATE | JSPROP_READONLY);
+
+    JS::RootedString jRevision(cx, JS_NewStringCopyZ(cx, NIDIUM_BUILD));
+    JS_DefineProperty(cx, nidiumObj, "revision", jRevision,
+                      JSPROP_PERMANENT | JSPROP_ENUMERATE | JSPROP_READONLY);
+
+    JS::RootedValue val(cx, JS::ObjectValue(*nidiumObj));
+    JS_SetProperty(cx, windowObj, "__nidium__", val);
+}
+
 JSWindow *JSWindow::RegisterObject(JSContext *cx,
                                    int width,
                                    int height,
@@ -1210,28 +1231,9 @@ JSWindow *JSWindow::RegisterObject(JSContext *cx,
     jwin->setUniqueInstance();
 
     jwin->createMainCanvas(width, height, docObj);
+    jwin->RegisterNidiumObject(cx);
 
-    // Set the __nidium__ properties
-    JS::RootedObject nidiumObj(cx, JS_NewPlainObject(cx));
-
-    JS::RootedValue val(cx);
-
-    JS::RootedString jVersion(cx, JS_NewStringCopyZ(cx, NIDIUM_VERSION_STR));
-    JS_DefineProperty(cx, nidiumObj, "version", jVersion,
-                      JSPROP_PERMANENT | JSPROP_ENUMERATE | JSPROP_READONLY);
-
-    JS::RootedString jBuild(cx, JS_NewStringCopyZ(cx, NIDIUM_BUILD));
-    JS_DefineProperty(cx, nidiumObj, "build", jBuild,
-                      JSPROP_PERMANENT | JSPROP_ENUMERATE | JSPROP_READONLY);
-
-    JS::RootedString jRevision(cx, JS_NewStringCopyZ(cx, NIDIUM_BUILD));
-    JS_DefineProperty(cx, nidiumObj, "revision", jRevision,
-                      JSPROP_PERMANENT | JSPROP_ENUMERATE | JSPROP_READONLY);
-
-    val = JS::ObjectValue(*nidiumObj);
-    JS_SetProperty(cx, windowObj, "__nidium__", val);
-
-#if 0
+    #if 0
     //@TODO: intented to be used in a future
     JS::RootedObject titleBar(cx, JSCanvas::GenerateJSObject(cx, width, 35));
     static_cast<CanvasHandler *>(JS_GetPrivate(canvas))->translate(0, 35);

--- a/src/Binding/JSWindow.h
+++ b/src/Binding/JSWindow.h
@@ -107,7 +107,7 @@ protected:
 
 private:
     bool dragEvent(const char *name, int x, int y);
-
+    static void RegisterNidiumObject(JSContext *cx);
     void createMainCanvas(int width, int height, JS::HandleObject docObj);
 
     struct _requestedFrame

--- a/tests/jsunittest/Window/__nidium__.js
+++ b/tests/jsunittest/Window/__nidium__.js
@@ -1,0 +1,20 @@
+/*
+   Copyright 2016 Nidium Inc. All rights reserved.
+   Use of this source code is governed by a MIT license
+   that can be found in the LICENSE file.
+*/
+
+Tests.register("Window.__nidium__", function() {
+    var nidium = window.__nidium__;
+    console.log(nidium.build.length);
+
+    Assert.equal(typeof nidium, "object", "Window.__nidium__ should be a object");
+    Assert.equal(typeof nidium.version, "string", "__nidium__.version should  be \"string\"");
+    Assert.notEqual(nidium.version.indexOf('.'), -1, "__nidium__.version should  have at least one '.'");
+    Assert.equal(typeof nidium.build, "string", "__nidium__.build should  be \"string\"");
+    Assert.equal(nidium.build.length, 40, "__nidium__.build should  be 40 characters long.");
+    Assert.equal(typeof nidium.revision, "string", "__nidium__.revision should  be \"string\"");
+    Assert.equal(nidium.revision.length, 40, "__nidium__.revision should  be 40 characters long.");
+});
+
+

--- a/tests/jsunittest/unittests.js
+++ b/tests/jsunittest/unittests.js
@@ -102,6 +102,7 @@ if (args["file"]) {
             'Image.js',
             'Canvas.js',
             'DB.js', // Only for frontend, because server does not support "cache://"
+            'Window/__nidium__.js',
         ]);
     }
 };


### PR DESCRIPTION
This is a first step in the preparations for webidl.
Further discussion is needed how this should be handeld:

* a seperate instance (ClassMapper) is probably too 'heavy'.
* a direct tweak on idlspec is probably too 'dirty'.