### PR TITLE
Implementation of File.mkdir() and Fix for File.rm()

### DIFF
--- a/src/Binding/JSFile.cpp
+++ b/src/Binding/JSFile.cpp
@@ -287,9 +287,32 @@ bool JSFile::JS_isDir(JSContext *cx, JS::CallArgs &args)
     return true;
 }
 
+bool JSFile::JS_mkdir(JSContext *cx, JS::CallArgs &args)
+{
+
+    File *file = this->getFile();
+
+    int val = file->mkdir();
+    if (val == 0) {
+        args.rval().setBoolean(true);
+    } else {
+        args.rval().setBoolean(false);
+    }
+
+    return true;
+}
+
 bool JSFile::JS_rm(JSContext *cx, JS::CallArgs &args)
 {
-    this->getFile()->rm();
+
+    File *file = this->getFile();
+
+    int val = file->rm();
+    if (val == 0) {
+        args.rval().setBoolean(true);
+    } else {
+        args.rval().setBoolean(false);
+    }
 
     return true;
 }
@@ -814,6 +837,7 @@ JSFunctionSpec *JSFile::ListMethods()
         CLASSMAPPER_FN(JSFile, isDir, 0),
         CLASSMAPPER_FN(JSFile, listFiles, 1),
 
+        CLASSMAPPER_FN(JSFile, mkdir, 0);
         CLASSMAPPER_FN(JSFile, rm, 0),
         CLASSMAPPER_FN(JSFile, rmrf, 0),
         JS_FS_END

--- a/src/Binding/JSFile.cpp
+++ b/src/Binding/JSFile.cpp
@@ -837,7 +837,7 @@ JSFunctionSpec *JSFile::ListMethods()
         CLASSMAPPER_FN(JSFile, isDir, 0),
         CLASSMAPPER_FN(JSFile, listFiles, 1),
 
-        CLASSMAPPER_FN(JSFile, mkDir, 0);
+        CLASSMAPPER_FN(JSFile, mkDir, 0),
         CLASSMAPPER_FN(JSFile, rm, 0),
         CLASSMAPPER_FN(JSFile, rmrf, 0),
         JS_FS_END

--- a/src/Binding/JSFile.cpp
+++ b/src/Binding/JSFile.cpp
@@ -291,13 +291,9 @@ bool JSFile::JS_mkDir(JSContext *cx, JS::CallArgs &args)
 {
 
     File *file = this->getFile();
-
     int val = file->mkDir();
-    if (val == 0) {
-        args.rval().setBoolean(true);
-    } else {
-        args.rval().setBoolean(false);
-    }
+
+    args.rval().setBoolean(val == 0);
 
     return true;
 }
@@ -308,11 +304,8 @@ bool JSFile::JS_rm(JSContext *cx, JS::CallArgs &args)
     File *file = this->getFile();
 
     int val = file->rm();
-    if (val == 0) {
-        args.rval().setBoolean(true);
-    } else {
-        args.rval().setBoolean(false);
-    }
+
+    args.rval().setBoolean(val == 0);
 
     return true;
 }

--- a/src/Binding/JSFile.cpp
+++ b/src/Binding/JSFile.cpp
@@ -287,12 +287,12 @@ bool JSFile::JS_isDir(JSContext *cx, JS::CallArgs &args)
     return true;
 }
 
-bool JSFile::JS_mkdir(JSContext *cx, JS::CallArgs &args)
+bool JSFile::JS_mkDir(JSContext *cx, JS::CallArgs &args)
 {
 
     File *file = this->getFile();
 
-    int val = file->mkdir();
+    int val = file->mkDir();
     if (val == 0) {
         args.rval().setBoolean(true);
     } else {
@@ -837,7 +837,7 @@ JSFunctionSpec *JSFile::ListMethods()
         CLASSMAPPER_FN(JSFile, isDir, 0),
         CLASSMAPPER_FN(JSFile, listFiles, 1),
 
-        CLASSMAPPER_FN(JSFile, mkdir, 0);
+        CLASSMAPPER_FN(JSFile, mkDir, 0);
         CLASSMAPPER_FN(JSFile, rm, 0),
         CLASSMAPPER_FN(JSFile, rmrf, 0),
         JS_FS_END

--- a/src/Binding/JSFile.h
+++ b/src/Binding/JSFile.h
@@ -77,7 +77,7 @@ protected:
     NIDIUM_DECL_JSCALL(writeSync);
     NIDIUM_DECL_JSCALL(isDir);
     NIDIUM_DECL_JSCALL(listFiles);
-    NIDIUM_DECL_JSCALL(mkdir);
+    NIDIUM_DECL_JSCALL(mkDir);
     NIDIUM_DECL_JSCALL(rm);
     NIDIUM_DECL_JSCALL(rmrf);
 

--- a/src/Binding/JSFile.h
+++ b/src/Binding/JSFile.h
@@ -77,6 +77,7 @@ protected:
     NIDIUM_DECL_JSCALL(writeSync);
     NIDIUM_DECL_JSCALL(isDir);
     NIDIUM_DECL_JSCALL(listFiles);
+    NIDIUM_DECL_JSCALL(mkdir);
     NIDIUM_DECL_JSCALL(rm);
     NIDIUM_DECL_JSCALL(rmrf);
 

--- a/src/IO/File.cpp
+++ b/src/IO/File.cpp
@@ -94,7 +94,7 @@ void File::checkRead(bool async, void *arg)
 int File::mkDir()
 {
 
-    int ret = mkdir(m_Path);
+    int ret = mkdir(m_Path, 0777);
 
     return ret;
 

--- a/src/IO/File.cpp
+++ b/src/IO/File.cpp
@@ -91,7 +91,7 @@ void File::checkRead(bool async, void *arg)
     }
 }
 
-int File::mkdir()
+int File::mkDir()
 {
 
     int ret = mkdir(m_Path);

--- a/src/IO/File.cpp
+++ b/src/IO/File.cpp
@@ -91,6 +91,15 @@ void File::checkRead(bool async, void *arg)
     }
 }
 
+int File::mkdir()
+{
+
+    int ret = mkdir(m_Path);
+
+    return ret;
+
+}
+
 int File::rm()
 {
     int ret = unlink(m_Path);

--- a/src/IO/File.h
+++ b/src/IO/File.h
@@ -56,7 +56,7 @@ public:
     void seek(size_t pos, void *arg = NULL);
     void listFiles(void *arg = NULL);
     void rmrf();
-    int mkdir();
+    int mkDir();
     int rm();
 
     /*

--- a/src/IO/File.h
+++ b/src/IO/File.h
@@ -56,6 +56,7 @@ public:
     void seek(size_t pos, void *arg = NULL);
     void listFiles(void *arg = NULL);
     void rmrf();
+    int mkdir();
     int rm();
 
     /*

--- a/tests/jsunittest/File/File.js
+++ b/tests/jsunittest/File/File.js
@@ -28,14 +28,14 @@ Tests.register("File (outside root)", function() {
 // {{{ Properties
 Tests.register("File.filename", function() {
     var f = new File(__filename);
-    Assert.equal(f.filename, __filename, 
+    Assert.equal(f.filename, __filename,
             "Expected filename to be \"" + __filename + "\" but got " + f.filename + "\"");
 });
 
 Tests.register("File.filesize", function() {
     var f = new File("File/doesexists/simplefile.txt");
     f.openSync("r");
-    Assert.equal(f.filesize, 9, 
+    Assert.equal(f.filesize, 9,
             "Expected filesize to be \"9\" but got \"" + f.filesize+ "\"");
 });
 // }}}
@@ -51,7 +51,7 @@ Tests.register("File.open (inexistent file exception)", function() {
 Tests.registerAsync("File.open (writing)", function(next) {
     var f = new File("File/file_open_write_test");
     f.open("w+", function(err) {
-        Assert.equal(err, undefined, 
+        Assert.equal(err, undefined,
                 "Got an error while trying to open file for writing : " + err);
         f.rm();
         next();
@@ -61,8 +61,8 @@ Tests.registerAsync("File.open (writing)", function(next) {
 Tests.registerAsync("File.open (reading)", function(next) {
     var f = new File(__filename);
     f.open("r", function(err) {
-        Assert.equal(err, undefined, 
-                "Got an error while trying to open file " + __filename + 
+        Assert.equal(err, undefined,
+                "Got an error while trying to open file " + __filename +
                 " for reading : " + err);
         next();
     });
@@ -137,6 +137,19 @@ Tests.register("File.isDir",  function() {
         fileObject.openSync("r");
 
         Assert.equal(fileObject.isDir(), expected, "Path \"" + path + "\" should be a " + (cases[path] ? "directory" : "file"));
+    }
+
+});
+
+Tests.register("File.mkdir", function() {
+
+    var result = File.mkdir('File/dir_to_create');
+    if (result === true) {
+
+        var check = new File('File/dir_to_create');
+
+        Assert.equal(check.isDir(), true, "Path \"File/dir_to_create\" should be a directory");
+
     }
 
 });
@@ -242,10 +255,10 @@ Tests.registerAsync("File.write", function(next) {
         f.seek(0, function() {
             var wroteContent = f.readSync();
 
-            Assert.equal(f.filesize, content.length, 
+            Assert.equal(f.filesize, content.length,
                     "Expected filesize to be " + content.length + " but got " + f.filesize);
 
-            Assert.equal(wroteContent, content, 
+            Assert.equal(wroteContent, content,
                     "Expected wrote content to be \"" + content + "\" but got \"" + wroteContent + "\"");
             f.rm();
             next();
@@ -267,7 +280,7 @@ Tests.register("File.writeSync", function(next) {
     Assert.equal(f.filesize, content.length,
             "Expected filesize to be " + content.length + " but got " + f.filesize);
 
-    Assert.equal(wroteContent, content, 
+    Assert.equal(wroteContent, content,
             "Expected wrote content to be \"" + content + "\" but got \"" + wroteContent + "\"");
 
     f.rm();
@@ -282,7 +295,7 @@ Tests.registerAsync("File.write (utf8)", function(next) {
 
         f.seek(0, function() {
             var wroteContent = f.readSync();
-            Assert.equal(wroteContent, content, 
+            Assert.equal(wroteContent, content,
                     "Expected wrote content to be \"" + content + "\" but got \"" + wroteContent + "\"");
             f.rm();
             next();
@@ -301,7 +314,7 @@ Tests.register("File.writeSync (utf8)", function(next) {
 
     wroteContent = f.readSync();
 
-    Assert.equal(wroteContent, content, 
+    Assert.equal(wroteContent, content,
             "Expected wrote content to be \"" + content + "\" but got \"" + wroteContent + "\"");
 
     f.rm();

--- a/tests/jsunittest/File/File.js
+++ b/tests/jsunittest/File/File.js
@@ -141,9 +141,9 @@ Tests.register("File.isDir",  function() {
 
 });
 
-Tests.register("File.mkdir", function() {
+Tests.register("File.mkDir", function() {
 
-    var result = File.mkdir('File/dir_to_create');
+    var result = File.mkDir('File/dir_to_create');
     if (result === true) {
 
         var check = new File('File/dir_to_create');


### PR DESCRIPTION
This implements File.mkdir(path) API and fixes the return value of File.rm();

Now both methods will return true on success and false on failure.
The test for File.mkdir() is also included, assuming that File/dir_to_create does not exist yet.
