### PR TITLE
chore: fix build due to relocated libjpeg-turbo repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,14 @@ You can download nidium binaries for Linux and OSX from the [download page](http
 
 ## Building nidium
 
-To build nidium you need at least 5.7GB of disk space. A build from scratch may take 30 to 90 minutes, depending of the speed of your computer.
+To build nidium you need:
+ - at least 5.7GB of disk space.
+ - an account on *.googlesource.com (https://skia.googlesource.com/new-password)
+   You will be prompted to login during the `./configure_frontend` step.
 
-On a debian based system, a few commands will get you started.
+A build from scratch may take 30 to 90 minutes, depending of the speed of your computer.
+
+### On a debian based system, a few commands will get you started.
 
 ```
 $ apt-get install libpci-dev python2.7 git make patch clang pkg-config libgtk2.0-dev libgtk-3-dev mesa-common-dev libglu1-mesa-dev libosmesa6-dev yasm libasound2 libasound2-dev libbz2-1.0
@@ -78,7 +83,7 @@ $ ./configure_frontend
 $ ./bin/nidium
 ```
 
-On a mac-os based system you need xcode installed.
+### On a mac-os based system you need xcode installed.
 
 ```
 sudo xcode-select -s /Applications/Xcode.app/Contents/Developer

--- a/configure_frontend
+++ b/configure_frontend
@@ -112,6 +112,13 @@ def skia():
             "-Wno-unused-template",
             "-Wno-zero-as-null-pointer-constant",
             "-Wno-expansion-to-defined",
+
+            "-Wno-null-pointer-arithmetic",
+            "-Wno-redundant-parens",
+            "-Wno-return-std-move-in-c++11",
+            "-Wno-self-assign-overloaded",
+            "-Wno-tautological-type-limit-compare",
+            "-Wno-tautological-unsigned-enum-zero-compare",
             "-DGR_GL_CUSTOM_SETUP_HEADER=<../../../../../patch/skia_gl_config.h>"
         ],
         "is_official_build": True,
@@ -150,6 +157,8 @@ def skia():
     return {
         "location": Deps.GitRepo("https://skia.googlesource.com/skia.git", branch="chrome/m58"),
         "build": [
+            '''sed -i.bak -e  's/third_party\/libjpeg-turbo\.git@.*/external\/github.com\/libjpeg-turbo\/libjpeg-turbo.git@1.5.3",/' DEPS''',
+            "cd ./third_party/externals/libjpeg-turbo && autoreconf -fiv && ./configure && cd -",
             "python tools/git-sync-deps",
             "bin/gn gen out/Static --args='%s'" % (skiaArgs),
             "sed -i.bak '/simpleperf/d' out/Static/build.ninja",


### PR DESCRIPTION
The libjpeg-turbo repository got an new location within the google infrastructure.
The skia chrome/m58 branch with that exact sha is not present at the new location.
The 1.5.3 is the next closest one that seems 'stable'.

Also, clang 7.0 has stricter error checking, and some '-Wno-' flags were added.